### PR TITLE
Do not include user-defined spectrum

### DIFF
--- a/frontend/src/components/spectrum/SpectrumSelector.tsx
+++ b/frontend/src/components/spectrum/SpectrumSelector.tsx
@@ -21,7 +21,7 @@ export default function SpectrumSelector({ onSelect }: Props) {
     "Blackbody",
     "Galaxy",
     "Emission Line",
-    "User-Defined",
+    // "User-Defined",
   ];
   return (
     <div>


### PR DESCRIPTION
Hide the option to add a user-defined spectrum.

The option should be shown again once user-defined spectra are supported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/nir-simulator/49)
<!-- Reviewable:end -->
